### PR TITLE
final clean up closing issue #30

### DIFF
--- a/TAP+SHACL/namespaces.csv
+++ b/TAP+SHACL/namespaces.csv
@@ -5,7 +5,6 @@ rdf,http://www.w3.org/1999/02/22-rdf-syntax-ns#,RDF
 rdfs,http://www.w3.org/2000/01/rdf-schema#,RDF Schema
 xsd,http://www.w3.org/2001/XMLSchema#,XSD: use for data types
 ex,http://example.org/,example
-cedso,http://ceds.ed.gov/owl#,Common Education Data Standards (draft OWL Ontology)
 ceds,http://ceds.ed.gov/terms#,Common Education Data Standards 12 (RDF/S vocabulary) 
 ceterms,https://purl.org/ctdl/terms/,Credential Transparency Description Language
 dc,http://purl.org/dc/elements/1.1/,"Dublin Core Metadata Element Set, Version 1.1"

--- a/TestFiles/fail_Organization.ttl
+++ b/TestFiles/fail_Organization.ttl
@@ -1,4 +1,4 @@
-@prefix cedso: <http://ceds.ed.gov/owl#> .
+
 @prefix ceds: <http://ceds.ed.gov/terms#> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
 @prefix pesc: <https://pesc.org/terms/> .
@@ -51,7 +51,7 @@
     ceds:P600336 [ a ceds:C200377 ;
             ceds:P000115 "Testy"^^xsd:token ;
             ceds:P000172 "Test"^^xsd:token ;
-            cedso:nameCode pescNameCodes:Legal ] ;
+            pesc:nameCode pescNameCodes:Legal ] ;
     pesc:achievement <https://example.edu/achievement001> .
 
 <https://example.edu/achievement001> a pesc:AcademicAchievement,

--- a/TestFiles/fail_PersonName.rslt
+++ b/TestFiles/fail_PersonName.rslt
@@ -4,112 +4,112 @@ Results (10):
 Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: ex:personnameshapeFirstName
-	Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]
+	Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]
 	Value Node: Literal("12", datatype=xsd:integer)
 	Result Path: ceds:P000115
 	Message: Value is not Literal with datatype xsd:token
 Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: ex:personnameshapeLastName
-	Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+	Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 	Value Node: Literal("Test")
 	Result Path: ceds:P000172
 	Message: Value is not Literal with datatype xsd:token
 Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: ex:personnameshapeLastName
-	Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]
+	Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]
 	Value Node: Literal("12", datatype=xsd:integer)
 	Result Path: ceds:P000172
 	Message: Value is not Literal with datatype xsd:token
 Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: ex:personnameshapeMiddleName
-	Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+	Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 	Value Node: Literal("Example")
 	Result Path: ceds:P000184
 	Message: Value is not Literal with datatype xsd:token
 Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: ex:personnameshapeNamePrefix
-	Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+	Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 	Value Node: Literal("Dr")
 	Result Path: ceds:P000212
 	Message: Value is not Literal with datatype xsd:token
 Constraint Violation in InConstraintComponent (http://www.w3.org/ns/shacl#InConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: ex:personnameshapeNameSuffix
-	Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+	Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 	Value Node: Literal("9", datatype=xsd:integer)
 	Result Path: ceds:P000121
 	Message: Value Literal("9", datatype=xsd:integer) not in list ['Literal("I")', 'Literal("X")', 'Literal("II")', 'Literal("VII")', 'Literal("SR")', 'Literal("IV")', 'Literal("VIII")', 'Literal("IX")', 'Literal("JR")', 'Literal("III")', 'Literal("VI")', 'Literal("V")']
 Constraint Violation in HasValueConstraintComponent (http://www.w3.org/ns/shacl#HasValueConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: ex:personnameshapeType
-	Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]
+	Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]
 	Result Path: rdf:type
-	Message: Node [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]->rdf:type does not contain a value in the set: ['ceds:C200377']
+	Message: Node [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]->rdf:type does not contain a value in the set: ['ceds:C200377']
 Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: ex:studentshapeHasOtherPersonName
 	Focus Node: <https://people.pjjk.net/test>
-	Value Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]
+	Value Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]
 	Result Path: ceds:P600101
 	Message: Value does not conform to Shape ex:PersonNameShape. See details for more information.
 	Details:
 		Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 			Severity: sh:Violation
 			Source Shape: ex:personnameshapeFirstName
-			Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]
+			Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]
 			Value Node: Literal("12", datatype=xsd:integer)
 			Result Path: ceds:P000115
 			Message: Value is not Literal with datatype xsd:token
 		Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 			Severity: sh:Violation
 			Source Shape: ex:personnameshapeLastName
-			Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]
+			Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]
 			Value Node: Literal("12", datatype=xsd:integer)
 			Result Path: ceds:P000172
 			Message: Value is not Literal with datatype xsd:token
 		Constraint Violation in HasValueConstraintComponent (http://www.w3.org/ns/shacl#HasValueConstraintComponent):
 			Severity: sh:Violation
 			Source Shape: ex:personnameshapeType
-			Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]
+			Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]
 			Result Path: rdf:type
-			Message: Node [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]->rdf:type does not contain a value in the set: ['ceds:C200377']
+			Message: Node [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]->rdf:type does not contain a value in the set: ['ceds:C200377']
 Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: ex:studentshapeHasPersonName
 	Focus Node: <https://people.pjjk.net/test>
-	Value Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+	Value Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 	Result Path: ceds:P600336
 	Message: Value does not conform to Shape ex:PersonNameShape. See details for more information.
 	Details:
 		Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 			Severity: sh:Violation
 			Source Shape: ex:personnameshapeLastName
-			Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+			Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 			Value Node: Literal("Test")
 			Result Path: ceds:P000172
 			Message: Value is not Literal with datatype xsd:token
 		Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 			Severity: sh:Violation
 			Source Shape: ex:personnameshapeMiddleName
-			Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+			Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 			Value Node: Literal("Example")
 			Result Path: ceds:P000184
 			Message: Value is not Literal with datatype xsd:token
 		Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 			Severity: sh:Violation
 			Source Shape: ex:personnameshapeNamePrefix
-			Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+			Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 			Value Node: Literal("Dr")
 			Result Path: ceds:P000212
 			Message: Value is not Literal with datatype xsd:token
 		Constraint Violation in InConstraintComponent (http://www.w3.org/ns/shacl#InConstraintComponent):
 			Severity: sh:Violation
 			Source Shape: ex:personnameshapeNameSuffix
-			Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+			Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 			Value Node: Literal("9", datatype=xsd:integer)
 			Result Path: ceds:P000121
 			Message: Value Literal("9", datatype=xsd:integer) not in list ['Literal("I")', 'Literal("X")', 'Literal("II")', 'Literal("VII")', 'Literal("SR")', 'Literal("IV")', 'Literal("VIII")', 'Literal("IX")', 'Literal("JR")', 'Literal("III")', 'Literal("VI")', 'Literal("V")']
@@ -125,63 +125,63 @@ Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#Node
 			Severity: sh:Violation
 			Source Shape: ex:studentshapeHasOtherPersonName
 			Focus Node: <https://people.pjjk.net/test>
-			Value Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]
+			Value Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]
 			Result Path: ceds:P600101
 			Message: Value does not conform to Shape ex:PersonNameShape. See details for more information.
 			Details:
 				Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 					Severity: sh:Violation
 					Source Shape: ex:personnameshapeFirstName
-					Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]
+					Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]
 					Value Node: Literal("12", datatype=xsd:integer)
 					Result Path: ceds:P000115
 					Message: Value is not Literal with datatype xsd:token
 				Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 					Severity: sh:Violation
 					Source Shape: ex:personnameshapeLastName
-					Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]
+					Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]
 					Value Node: Literal("12", datatype=xsd:integer)
 					Result Path: ceds:P000172
 					Message: Value is not Literal with datatype xsd:token
 				Constraint Violation in HasValueConstraintComponent (http://www.w3.org/ns/shacl#HasValueConstraintComponent):
 					Severity: sh:Violation
 					Source Shape: ex:personnameshapeType
-					Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]
+					Focus Node: [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]
 					Result Path: rdf:type
-					Message: Node [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type cedso:WrongClass ]->rdf:type does not contain a value in the set: ['ceds:C200377']
+					Message: Node [ ceds:P000115 Literal("12", datatype=xsd:integer) ; ceds:P000172 Literal("12", datatype=xsd:integer) ; rdf:type ceds:WrongClass ]->rdf:type does not contain a value in the set: ['ceds:C200377']
 		Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
 			Severity: sh:Violation
 			Source Shape: ex:studentshapeHasPersonName
 			Focus Node: <https://people.pjjk.net/test>
-			Value Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+			Value Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 			Result Path: ceds:P600336
 			Message: Value does not conform to Shape ex:PersonNameShape. See details for more information.
 			Details:
 				Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 					Severity: sh:Violation
 					Source Shape: ex:personnameshapeLastName
-					Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+					Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 					Value Node: Literal("Test")
 					Result Path: ceds:P000172
 					Message: Value is not Literal with datatype xsd:token
 				Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 					Severity: sh:Violation
 					Source Shape: ex:personnameshapeMiddleName
-					Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+					Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 					Value Node: Literal("Example")
 					Result Path: ceds:P000184
 					Message: Value is not Literal with datatype xsd:token
 				Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 					Severity: sh:Violation
 					Source Shape: ex:personnameshapeNamePrefix
-					Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+					Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 					Value Node: Literal("Dr")
 					Result Path: ceds:P000212
 					Message: Value is not Literal with datatype xsd:token
 				Constraint Violation in InConstraintComponent (http://www.w3.org/ns/shacl#InConstraintComponent):
 					Severity: sh:Violation
 					Source Shape: ex:personnameshapeNameSuffix
-					Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; cedso:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
+					Focus Node: [ ceds:P000115 Literal("Testy", datatype=xsd:token) ; ceds:P000121 Literal("9", datatype=xsd:integer) ; ceds:P000172 Literal("Test") ; ceds:P000184 Literal("Example") ; ceds:P000212 Literal("Dr") ; pesc:nameCode pescNameCodes:Legal ; rdf:type ceds:C200377 ]
 					Value Node: Literal("9", datatype=xsd:integer)
 					Result Path: ceds:P000121
 					Message: Value Literal("9", datatype=xsd:integer) not in list ['Literal("I")', 'Literal("X")', 'Literal("II")', 'Literal("VII")', 'Literal("SR")', 'Literal("IV")', 'Literal("VIII")', 'Literal("IX")', 'Literal("JR")', 'Literal("III")', 'Literal("VI")', 'Literal("V")']

--- a/TestFiles/fail_PersonName.ttl
+++ b/TestFiles/fail_PersonName.ttl
@@ -1,4 +1,4 @@
-@prefix cedso: <http://ceds.ed.gov/owl#> .
+
 @prefix ceds: <http://ceds.ed.gov/terms#> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
 @prefix pesc: <https://pesc.org/terms/> .
@@ -54,8 +54,8 @@
             ceds:P000184 "Example" ; # error wrong type
             ceds:P000172 "Test" ;
             ceds:P000121 9 ; # error not in list
-            cedso:nameCode pescNameCodes:Legal ] ;
-    ceds:P600101 [ a cedso:WrongClass ; #error wrong class
+            pesc:nameCode pescNameCodes:Legal ] ;
+    ceds:P600101 [ a ceds:WrongClass ; #error wrong class
             ceds:P000115 12 ; 
             ceds:P000172 12 ] ;
     pesc:achievement <https://example.edu/achievement001> .

--- a/TestFiles/fail_address.ttl
+++ b/TestFiles/fail_address.ttl
@@ -1,4 +1,4 @@
-@prefix cedso: <http://ceds.ed.gov/owl#> .
+
 @prefix ceds: <http://ceds.ed.gov/terms#> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
@@ -51,7 +51,7 @@
     ceds:P600336 [ a ceds:C200377 ;
             ceds:P000115 "Testy"^^xsd:token ;
             ceds:P000172 "Test"^^xsd:token ;
-            cedso:nameCode pescNameCodes:Legal ] ;
+            pesc:nameCode pescNameCodes:Legal ] ;
     ceterms:targetContactPoint [
         a ceterms:ContactPoint ;
         ceterms:contactType "Home address"@en ;

--- a/TestFiles/fail_birth.ttl
+++ b/TestFiles/fail_birth.ttl
@@ -1,4 +1,4 @@
-@prefix cedso: <http://ceds.ed.gov/owl#> .
+
 @prefix ceds: <http://ceds.ed.gov/terms#> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
 @prefix pesc: <https://pesc.org/terms/> .
@@ -50,7 +50,7 @@
     ceds:P600336 [ a ceds:C200377 ;
             ceds:P000115 "Testy"^^xsd:token ;
             ceds:P000172 "Test"^^xsd:token ;
-            cedso:nameCode pescNameCodes:Legal ] ;
+            pesc:nameCode pescNameCodes:Legal ] ;
     ceds:P000033 "January 1 2000" ;
     pesc:birthday "January 1" ;
     pesc:birthYear "2000"^^xsd:date ;

--- a/TestFiles/fail_gender+deceased.ttl
+++ b/TestFiles/fail_gender+deceased.ttl
@@ -1,4 +1,4 @@
-@prefix cedso: <http://ceds.ed.gov/owl#> .
+
 @prefix ceds: <http://ceds.ed.gov/terms#> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
 @prefix pesc: <https://pesc.org/terms/> .
@@ -50,7 +50,7 @@
     ceds:P600336 [ a ceds:C200377 ;
             ceds:P000115 "Testy"^^xsd:token ;
             ceds:P000172 "Test"^^xsd:token ;
-            cedso:nameCode pescNameCodes:Legal ] ;
+            pesc:nameCode pescNameCodes:Legal ] ;
     pesc:deceasedIndicator "Yes" ;
     pesc:genderCode "Unreported" ;
     pesc:achievement <https://example.edu/achievement001> .

--- a/TestFiles/fail_noIDinID.ttl
+++ b/TestFiles/fail_noIDinID.ttl
@@ -1,4 +1,4 @@
-@prefix cedso: <http://ceds.ed.gov/owl#> .
+
 @prefix ceds: <http://ceds.ed.gov/terms#> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
 @prefix pesc: <https://pesc.org/terms/> .
@@ -50,7 +50,7 @@
     ceds:P600336 [ a ceds:C200377 ;
             ceds:P000115 "Testy"^^xsd:token ;
             ceds:P000172 "Test"^^xsd:token ;
-            cedso:nameCode pescNameCodes:Legal ] ;
+            pesc:nameCode pescNameCodes:Legal ] ;
     ceds:P600049 [
         a ceds:C200291  ;
         # fail no ceds:P001572 "123456789"^^xsd:string ;

--- a/TestFiles/fail_orgID.ttl
+++ b/TestFiles/fail_orgID.ttl
@@ -1,4 +1,4 @@
-@prefix cedso: <http://ceds.ed.gov/owl#> .
+
 @prefix ceds: <http://ceds.ed.gov/terms#> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
 @prefix pesc: <https://pesc.org/terms/> .
@@ -51,7 +51,7 @@
     ceds:P600336 [ a ceds:C200377 ;
             ceds:P000115 "Testy"^^xsd:token ;
             ceds:P000172 "Test"^^xsd:token ;
-            cedso:nameCode pescNameCodes:Legal ] ;
+            pesc:nameCode pescNameCodes:Legal ] ;
     pesc:achievement <https://example.edu/achievement001> .
 
 <https://example.edu/achievement001> a pesc:AcademicAchievement,

--- a/TestFiles/fail_phone.rslt
+++ b/TestFiles/fail_phone.rslt
@@ -3,130 +3,16 @@ Conforms: False
 Results (9):
 Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
 	Severity: sh:Violation
-	Source Shape: ex:collegetranscriptshapeStudent
-	Focus Node: <https://example.edu/transcripts/050330001>
-	Value Node: <https://people.pjjk.net/test>
-	Result Path: pesc:student
-	Message: Value does not conform to Shape ex:StudentShape. See details for more information.
-	Details:
-		Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
-			Severity: sh:Violation
-			Source Shape: ex:studentshapeContact
-			Focus Node: <https://people.pjjk.net/test>
-			Value Node: [ cedso:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; cedso:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
-			Result Path: ceterms:targetContactPoint
-			Message: Value does not conform to Shape ex:ContactShape. See details for more information.
-			Details:
-				Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
-					Severity: sh:Violation
-					Source Shape: ex:contactshapeFAXPhone
-					Focus Node: [ cedso:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; cedso:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
-					Value Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
-					Result Path: pesc:faxPhone
-					Message: Value does not conform to Shape ex:PhoneShape. See details for more information.
-					Details:
-						Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
-							Severity: sh:Violation
-							Source Shape: ex:phoneshapeCountryPrefixCode
-							Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
-							Value Node: Literal("34", datatype=xsd:integer)
-							Result Path: pesc:countryPrefixCode
-							Message: Value is not Literal with datatype xsd:string
-						Constraint Violation in MinCountConstraintComponent (http://www.w3.org/ns/shacl#MinCountConstraintComponent):
-							Severity: sh:Violation
-							Source Shape: ex:phoneshapePhoneNumber
-							Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
-							Result Path: pesc:phoneNumber
-							Message: Less than 1 values on [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]->pesc:phoneNumber
-						Constraint Violation in MaxLengthConstraintComponent (http://www.w3.org/ns/shacl#MaxLengthConstraintComponent):
-							Severity: sh:Violation
-							Source Shape: ex:phoneshapePhoneNumberExtension
-							Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
-							Value Node: Literal("1234567890")
-							Result Path: pesc:phoneNumberExtension
-							Message: String length not <= Literal("5", datatype=xsd:integer)
-						Constraint Violation in HasValueConstraintComponent (http://www.w3.org/ns/shacl#HasValueConstraintComponent):
-							Severity: sh:Violation
-							Source Shape: ex:phoneshapeType
-							Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
-							Result Path: rdf:type
-							Message: Node [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]->rdf:type does not contain a value in the set: ['pesc:Phone']
-				Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
-					Severity: sh:Violation
-					Source Shape: ex:contactshapePhone
-					Focus Node: [ cedso:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; cedso:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
-					Value Node: [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ]
-					Result Path: pesc:phone
-					Message: Value does not conform to Shape ex:PhoneShape. See details for more information.
-					Details:
-						Constraint Violation in MaxLengthConstraintComponent (http://www.w3.org/ns/shacl#MaxLengthConstraintComponent):
-							Severity: sh:Violation
-							Source Shape: ex:phoneshapePhoneNumber
-							Focus Node: [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ]
-							Value Node: Literal("+34 555-123-4567 ext123")
-							Result Path: pesc:phoneNumber
-							Message: String length not <= Literal("11", datatype=xsd:integer)
-Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
-	Severity: sh:Violation
-	Source Shape: ex:contactshapeFAXPhone
-	Focus Node: [ cedso:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; cedso:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
-	Value Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
-	Result Path: pesc:faxPhone
-	Message: Value does not conform to Shape ex:PhoneShape. See details for more information.
-	Details:
-		Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
-			Severity: sh:Violation
-			Source Shape: ex:phoneshapeCountryPrefixCode
-			Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
-			Value Node: Literal("34", datatype=xsd:integer)
-			Result Path: pesc:countryPrefixCode
-			Message: Value is not Literal with datatype xsd:string
-		Constraint Violation in MinCountConstraintComponent (http://www.w3.org/ns/shacl#MinCountConstraintComponent):
-			Severity: sh:Violation
-			Source Shape: ex:phoneshapePhoneNumber
-			Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
-			Result Path: pesc:phoneNumber
-			Message: Less than 1 values on [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]->pesc:phoneNumber
-		Constraint Violation in MaxLengthConstraintComponent (http://www.w3.org/ns/shacl#MaxLengthConstraintComponent):
-			Severity: sh:Violation
-			Source Shape: ex:phoneshapePhoneNumberExtension
-			Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
-			Value Node: Literal("1234567890")
-			Result Path: pesc:phoneNumberExtension
-			Message: String length not <= Literal("5", datatype=xsd:integer)
-		Constraint Violation in HasValueConstraintComponent (http://www.w3.org/ns/shacl#HasValueConstraintComponent):
-			Severity: sh:Violation
-			Source Shape: ex:phoneshapeType
-			Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
-			Result Path: rdf:type
-			Message: Node [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]->rdf:type does not contain a value in the set: ['pesc:Phone']
-Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
-	Severity: sh:Violation
-	Source Shape: ex:contactshapePhone
-	Focus Node: [ cedso:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; cedso:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
-	Value Node: [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ]
-	Result Path: pesc:phone
-	Message: Value does not conform to Shape ex:PhoneShape. See details for more information.
-	Details:
-		Constraint Violation in MaxLengthConstraintComponent (http://www.w3.org/ns/shacl#MaxLengthConstraintComponent):
-			Severity: sh:Violation
-			Source Shape: ex:phoneshapePhoneNumber
-			Focus Node: [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ]
-			Value Node: Literal("+34 555-123-4567 ext123")
-			Result Path: pesc:phoneNumber
-			Message: String length not <= Literal("11", datatype=xsd:integer)
-Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
-	Severity: sh:Violation
 	Source Shape: ex:studentshapeContact
 	Focus Node: <https://people.pjjk.net/test>
-	Value Node: [ cedso:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; cedso:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
+	Value Node: [ ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
 	Result Path: ceterms:targetContactPoint
 	Message: Value does not conform to Shape ex:ContactShape. See details for more information.
 	Details:
 		Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
 			Severity: sh:Violation
 			Source Shape: ex:contactshapeFAXPhone
-			Focus Node: [ cedso:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; cedso:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
+			Focus Node: [ ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
 			Value Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
 			Result Path: pesc:faxPhone
 			Message: Value does not conform to Shape ex:PhoneShape. See details for more information.
@@ -160,7 +46,7 @@ Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#Node
 		Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
 			Severity: sh:Violation
 			Source Shape: ex:contactshapePhone
-			Focus Node: [ cedso:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; cedso:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
+			Focus Node: [ ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
 			Value Node: [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ]
 			Result Path: pesc:phone
 			Message: Value does not conform to Shape ex:PhoneShape. See details for more information.
@@ -172,6 +58,120 @@ Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#Node
 					Value Node: Literal("+34 555-123-4567 ext123")
 					Result Path: pesc:phoneNumber
 					Message: String length not <= Literal("11", datatype=xsd:integer)
+Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
+	Severity: sh:Violation
+	Source Shape: ex:collegetranscriptshapeStudent
+	Focus Node: <https://example.edu/transcripts/050330001>
+	Value Node: <https://people.pjjk.net/test>
+	Result Path: pesc:student
+	Message: Value does not conform to Shape ex:StudentShape. See details for more information.
+	Details:
+		Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
+			Severity: sh:Violation
+			Source Shape: ex:studentshapeContact
+			Focus Node: <https://people.pjjk.net/test>
+			Value Node: [ ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
+			Result Path: ceterms:targetContactPoint
+			Message: Value does not conform to Shape ex:ContactShape. See details for more information.
+			Details:
+				Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
+					Severity: sh:Violation
+					Source Shape: ex:contactshapeFAXPhone
+					Focus Node: [ ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
+					Value Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
+					Result Path: pesc:faxPhone
+					Message: Value does not conform to Shape ex:PhoneShape. See details for more information.
+					Details:
+						Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
+							Severity: sh:Violation
+							Source Shape: ex:phoneshapeCountryPrefixCode
+							Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
+							Value Node: Literal("34", datatype=xsd:integer)
+							Result Path: pesc:countryPrefixCode
+							Message: Value is not Literal with datatype xsd:string
+						Constraint Violation in MinCountConstraintComponent (http://www.w3.org/ns/shacl#MinCountConstraintComponent):
+							Severity: sh:Violation
+							Source Shape: ex:phoneshapePhoneNumber
+							Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
+							Result Path: pesc:phoneNumber
+							Message: Less than 1 values on [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]->pesc:phoneNumber
+						Constraint Violation in MaxLengthConstraintComponent (http://www.w3.org/ns/shacl#MaxLengthConstraintComponent):
+							Severity: sh:Violation
+							Source Shape: ex:phoneshapePhoneNumberExtension
+							Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
+							Value Node: Literal("1234567890")
+							Result Path: pesc:phoneNumberExtension
+							Message: String length not <= Literal("5", datatype=xsd:integer)
+						Constraint Violation in HasValueConstraintComponent (http://www.w3.org/ns/shacl#HasValueConstraintComponent):
+							Severity: sh:Violation
+							Source Shape: ex:phoneshapeType
+							Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
+							Result Path: rdf:type
+							Message: Node [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]->rdf:type does not contain a value in the set: ['pesc:Phone']
+				Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
+					Severity: sh:Violation
+					Source Shape: ex:contactshapePhone
+					Focus Node: [ ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
+					Value Node: [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ]
+					Result Path: pesc:phone
+					Message: Value does not conform to Shape ex:PhoneShape. See details for more information.
+					Details:
+						Constraint Violation in MaxLengthConstraintComponent (http://www.w3.org/ns/shacl#MaxLengthConstraintComponent):
+							Severity: sh:Violation
+							Source Shape: ex:phoneshapePhoneNumber
+							Focus Node: [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ]
+							Value Node: Literal("+34 555-123-4567 ext123")
+							Result Path: pesc:phoneNumber
+							Message: String length not <= Literal("11", datatype=xsd:integer)
+Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
+	Severity: sh:Violation
+	Source Shape: ex:contactshapeFAXPhone
+	Focus Node: [ ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
+	Value Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
+	Result Path: pesc:faxPhone
+	Message: Value does not conform to Shape ex:PhoneShape. See details for more information.
+	Details:
+		Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
+			Severity: sh:Violation
+			Source Shape: ex:phoneshapeCountryPrefixCode
+			Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
+			Value Node: Literal("34", datatype=xsd:integer)
+			Result Path: pesc:countryPrefixCode
+			Message: Value is not Literal with datatype xsd:string
+		Constraint Violation in MinCountConstraintComponent (http://www.w3.org/ns/shacl#MinCountConstraintComponent):
+			Severity: sh:Violation
+			Source Shape: ex:phoneshapePhoneNumber
+			Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
+			Result Path: pesc:phoneNumber
+			Message: Less than 1 values on [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]->pesc:phoneNumber
+		Constraint Violation in MaxLengthConstraintComponent (http://www.w3.org/ns/shacl#MaxLengthConstraintComponent):
+			Severity: sh:Violation
+			Source Shape: ex:phoneshapePhoneNumberExtension
+			Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
+			Value Node: Literal("1234567890")
+			Result Path: pesc:phoneNumberExtension
+			Message: String length not <= Literal("5", datatype=xsd:integer)
+		Constraint Violation in HasValueConstraintComponent (http://www.w3.org/ns/shacl#HasValueConstraintComponent):
+			Severity: sh:Violation
+			Source Shape: ex:phoneshapeType
+			Focus Node: [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]
+			Result Path: rdf:type
+			Message: Node [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ]->rdf:type does not contain a value in the set: ['pesc:Phone']
+Constraint Violation in NodeConstraintComponent (http://www.w3.org/ns/shacl#NodeConstraintComponent):
+	Severity: sh:Violation
+	Source Shape: ex:contactshapePhone
+	Focus Node: [ ceterms:contactType Literal("Home phone", lang=en) ; elm:additionalNote [ elm:noteLiteral Literal("A made up contact.") ; rdf:type elm:Note ] ; pesc:RecordEndDateTime Literal("2021-01-01T00:00:00" = 2021-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:RecordStartDateTime Literal("2020-01-01T00:00:00" = 2020-01-01 00:00:00, datatype=xsd:dateTime) ; pesc:attentionLine Literal("Attn: Parent or Gardian of Testy Test", lang=en) ; pesc:faxPhone [ pesc:countryPrefixCode Literal("34", datatype=xsd:integer) ; pesc:phoneNumberExtension Literal("1234567890") ; rdf:type pesc:Fax ] ; pesc:phone [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ] ; rdf:type ceterms:ContactPoint ]
+	Value Node: [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ]
+	Result Path: pesc:phone
+	Message: Value does not conform to Shape ex:PhoneShape. See details for more information.
+	Details:
+		Constraint Violation in MaxLengthConstraintComponent (http://www.w3.org/ns/shacl#MaxLengthConstraintComponent):
+			Severity: sh:Violation
+			Source Shape: ex:phoneshapePhoneNumber
+			Focus Node: [ pesc:phoneNumber Literal("+34 555-123-4567 ext123") ; rdf:type pesc:Phone ]
+			Value Node: Literal("+34 555-123-4567 ext123")
+			Result Path: pesc:phoneNumber
+			Message: String length not <= Literal("11", datatype=xsd:integer)
 Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
 	Severity: sh:Violation
 	Source Shape: ex:phoneshapeCountryPrefixCode

--- a/TestFiles/fail_phone.ttl
+++ b/TestFiles/fail_phone.ttl
@@ -1,4 +1,4 @@
-@prefix cedso: <http://ceds.ed.gov/owl#> .
+
 @prefix ceds: <http://ceds.ed.gov/terms#> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
@@ -52,7 +52,7 @@
     ceds:P600336 [ a ceds:C200377 ;
             ceds:P000115 "Testy"^^xsd:token ;
             ceds:P000172 "Test"^^xsd:token ;
-            cedso:nameCode pescNameCodes:Legal ] ;
+            pesc:nameCode pescNameCodes:Legal ] ;
     ceterms:targetContactPoint [
         a ceterms:ContactPoint ;
         ceterms:contactType "Home phone"@en ;
@@ -67,8 +67,8 @@
             pesc:phoneNumberExtension "1234567890" ; # too long
         ] ;
         pesc:attentionLine "Attn: Parent or Gardian of Testy Test"@en ;
-        cedso:RecordStartDateTime "2020-01-01T00:00:00"^^xsd:dateTime ;
-        cedso:RecordEndDateTime "2021-01-01T00:00:00"^^xsd:dateTime ;
+        pesc:RecordStartDateTime "2020-01-01T00:00:00"^^xsd:dateTime ;
+        pesc:RecordEndDateTime "2021-01-01T00:00:00"^^xsd:dateTime ;
         elm:additionalNote [
             rdf:type elm:Note ;
             elm:noteLiteral "A made up contact." ;

--- a/TestFiles/fail_residency.ttl
+++ b/TestFiles/fail_residency.ttl
@@ -1,4 +1,4 @@
-@prefix cedso: <http://ceds.ed.gov/owl#> .
+
 @prefix ceds: <http://ceds.ed.gov/terms#> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
 @prefix pesc: <https://pesc.org/terms/> .
@@ -51,7 +51,7 @@
     ceds:P600336 [ a ceds:C200377 ;
             ceds:P000115 "Testy"^^xsd:token ;
             ceds:P000172 "Test"^^xsd:token ;
-            cedso:nameCode pescNameCodes:Legal ] ;
+            pesc:nameCode pescNameCodes:Legal ] ;
     pesc:achievement <https://example.edu/achievement001> ;
         pesc:hasResidency [
         a pesc:Residing ; # wrong class name

--- a/TestFiles/fail_unknownIDtype.ttl
+++ b/TestFiles/fail_unknownIDtype.ttl
@@ -1,4 +1,4 @@
-@prefix cedso: <http://ceds.ed.gov/owl#> .
+
 @prefix ceds: <http://ceds.ed.gov/terms#> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
 @prefix pesc: <https://pesc.org/terms/> .
@@ -50,7 +50,7 @@
     ceds:P600336 [ a ceds:C200377 ;
             ceds:P000115 "Testy"^^xsd:token ;
             ceds:P000172 "Test"^^xsd:token ;
-            cedso:nameCode pescNameCodes:Legal ] ;
+            pesc:nameCode pescNameCodes:Legal ] ;
     ceds:P600049 [
         a ceds:C200291 ;
         ceds:P001572 "123456789"^^xsd:string ;

--- a/TestFiles/maximal_passing.ttl
+++ b/TestFiles/maximal_passing.ttl
@@ -1,4 +1,4 @@
-@prefix cedso: <http://ceds.ed.gov/owl#> .
+
 @prefix ceds: <http://ceds.ed.gov/terms#> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
 @prefix elm:  <http://data.europa.eu/snb/model/elm/>.
@@ -61,7 +61,7 @@
             ceds:P000184 "Example"^^xsd:token ;
             ceds:P000172 "Test"^^xsd:token ;
             ceds:P000121 "IX" ;
-            cedso:nameCode pescNameCodes:Legal ] ;
+            pesc:nameCode pescNameCodes:Legal ] ;
     ceds:P600101 [ a ceds:C200377 ;
             ceds:P000115 "Testing"^^xsd:token ;
             ceds:P000172 "Testy"^^xsd:token ] ;
@@ -94,8 +94,8 @@
         ceterms:contactType "Home address"@en ;
         ceterms:address <https://example.org/address/001> ;
         pesc:attentionLine "Attn: Parent or Gardian of Testy Test"@en ;
-        cedso:RecordStartDateTime "2020-01-01T00:00:00"^^xsd:dateTime ;
-        cedso:RecordEndDateTime "2021-01-01T00:00:00"^^xsd:dateTime ;
+        pesc:RecordStartDateTime "2020-01-01T00:00:00"^^xsd:dateTime ;
+        pesc:RecordEndDateTime "2021-01-01T00:00:00"^^xsd:dateTime ;
         elm:additionalNote [
             rdf:type elm:Note ;
             elm:noteLiteral "A made up contact." ;
@@ -116,8 +116,8 @@
             pesc:phoneNumberExtension "123" ;
         ] ;
         pesc:attentionLine "Ask for Parent or Gardian of Testy Test"@en ;
-        cedso:RecordStartDateTime "2020-01-01T00:00:00"^^xsd:dateTime ;
-        cedso:RecordEndDateTime "2021-01-01T00:00:00"^^xsd:dateTime ;
+        pesc:RecordStartDateTime "2020-01-01T00:00:00"^^xsd:dateTime ;
+        pesc:RecordEndDateTime "2021-01-01T00:00:00"^^xsd:dateTime ;
         elm:additionalNote [
             rdf:type elm:Note ;
             elm:noteLiteral "A made up contact." ;

--- a/TestFiles/minimal_passing.ttl
+++ b/TestFiles/minimal_passing.ttl
@@ -1,4 +1,4 @@
-@prefix cedso: <http://ceds.ed.gov/owl#> .
+
 @prefix ceds: <http://ceds.ed.gov/terms#> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
 @prefix ceterms: <https://purl.org/ctdl/terms/> .
@@ -51,7 +51,7 @@
     ceds:P600336 [ a ceds:C200377 ;
             ceds:P000115 "Testy"^^xsd:token ;
             ceds:P000172 "Test"^^xsd:token ;
-            cedso:nameCode pescNameCodes:Legal ] ;
+            pesc:nameCode pescNameCodes:Legal ] ;
     pesc:achievement <https://example.edu/achievement001> .
 
 <https://example.edu/achievement001> a pesc:AcademicAchievement,


### PR DESCRIPTION
removing temporary cedso: namespace used for old ontology names
moving RecordStart/EndDate properties in Test files to pesc: namespace
fixing a property in examples that shouldn't have been in ceds namespace.
closes #30 