### PR TITLE
Licensure as subclass of Achievement

### DIFF
--- a/TAP+SHACL/shacl.ttl
+++ b/TAP+SHACL/shacl.ttl
@@ -135,6 +135,15 @@
     sh:name "Course Repeat Code"@en ;
     sh:targetClass pesc:CourseRepeatCode .
 
+<LicensureShape> a sh:NodeShape ;
+    sh:closed false ;
+    sh:name "Licensure"@en ;
+    sh:property <licensureshapeInCourse>,
+        <licensureshapeInProgram>,
+        <licensureshapeLicensureName>,
+        <licensureshapeLicensurePassageDate> ;
+    sh:targetClass pesc:Licensure .
+
 <OrganizationIdentifierShape> a sh:NodeShape ;
     sh:closed false ;
     sh:description "Normally type will be ceds:C200252"@en ;
@@ -224,14 +233,8 @@
         <courseachievementshapeCourseQualityPointsEarned>,
         <courseachievementshapeCourseRepeatCode>,
         <courseachievementshapeCourseSupplementalGrade>,
-        <courseachievementshapeInCourse>,
-        <courseachievementshapeLicensure> ;
+        <courseachievementshapeInCourse> ;
     sh:targetClass pesc:CourseAchievement .
-
-<CourseShape> a sh:NodeShape ;
-    sh:closed false ;
-    sh:name "Post Secondary Course"@en ;
-    sh:targetClass ceds:C200328 .
 
 <CourseSupplementalGradeShape> a sh:NodeShape ;
     sh:closed false ;
@@ -247,13 +250,6 @@
     sh:closed false ;
     sh:name "Person Language"@en ;
     sh:targetClass ceds:C200293 .
-
-<LicensureShape> a sh:NodeShape ;
-    sh:closed false ;
-    sh:name "Licensure"@en ;
-    sh:property <licensureshapeLicensureName>,
-        <licensureshapeLicensurePassageDate> ;
-    sh:targetClass pesc:Licensure .
 
 <NoteShape> a sh:NodeShape ;
     sh:closed false ;
@@ -761,12 +757,6 @@
     sh:nodeKind sh:BlankNodeOrIRI ;
     sh:path pesc:inCourse .
 
-<courseachievementshapeLicensure> a sh:PropertyShape ;
-    sh:name "Licensure"@en-US ;
-    sh:node <LicensureShape> ;
-    sh:nodeKind sh:BlankNodeOrIRI ;
-    sh:path pesc:licensure .
-
 <coursesupplementalgradeshapeCourseAcademicSupplementalGrade> a sh:PropertyShape ;
     sh:datatype xsd:string ;
     sh:maxCount 1 ;
@@ -886,6 +876,20 @@
     sh:name "Achievement "@en ;
     sh:targetObjectsOf pesc:hasAchievement,
         pesc:hasPart .
+
+<licensureshapeInCourse> a sh:PropertyShape ;
+    sh:maxCount 1 ;
+    sh:name "In Course"@en-US ;
+    sh:node <CourseShape> ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
+    sh:path pesc:inCourse .
+
+<licensureshapeInProgram> a sh:PropertyShape ;
+    sh:maxCount 1 ;
+    sh:name "In Program"@en-US ;
+    sh:node <AcademicProgramShape> ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
+    sh:path pesc:inProgram .
 
 <licensureshapeLicensureName> a sh:PropertyShape ;
     sh:datatype xsd:string ;
@@ -1070,6 +1074,11 @@
     sh:nodeKind sh:BlankNodeOrIRI ;
     sh:path cred:subject .
 
+<CourseShape> a sh:NodeShape ;
+    sh:closed false ;
+    sh:name "Post Secondary Course"@en ;
+    sh:targetClass ceds:C200328 .
+
 <GPAShape> a sh:NodeShape ;
     sh:closed false ;
     sh:name "GPA"@en ;
@@ -1098,13 +1107,13 @@
         <academichonorsshapeHonorsTitle> ;
     sh:targetClass pesc:AcademicHonors .
 
-<AcademicProgramShape> a sh:NodeShape ;
-    sh:closed false ;
-    sh:name "Academic Program"@en ;
-    sh:targetClass ceds:C200331 .
-
 <RAPShape> a sh:NodeShape ;
     sh:closed false ;
     sh:name "Requirement, Attribute or Proficiency"@en ;
     sh:targetClass ceds:C200065 .
+
+<AcademicProgramShape> a sh:NodeShape ;
+    sh:closed false ;
+    sh:name "Academic Program"@en ;
+    sh:targetClass ceds:C200331 .
 

--- a/TAP+SHACL/tap.csv
+++ b/TAP+SHACL/tap.csv
@@ -139,7 +139,6 @@ pescTransmissionTypes:MutuallyDefined",picklist,,Required,
 317,CourseAchievementShape,pesc:courseDropDate,Course Drop Date,FALSE,FALSE,Literal,xsd:date,,,,,
 325,CourseAchievementShape,pesc:courseSupplementalGrade,Course Supplemental Grade,FALSE,FALSE,IRI BNODE,,,,CourseSupplementalGradeShape,Required,
 388,CourseAchievementShape,pesc:inCourse,In Course,TRUE,FALSE,IRI BNODE,,,,CourseShape,Required,
-349,CourseAchievementShape,pesc:licensure,Licensure,FALSE,TRUE,IRI BNODE,,,,LicensureShape,Optional,
 294,CourseAchievementShape,pesc:courseCreditEarned,Course Credit Earned,FALSE,FALSE,Literal,xsd:decimal,,,,Recommended,decimal
 296,CourseAchievementShape,pesc:courseAcademicGrade,Course Academic Grade,FALSE,FALSE,Literal,xsd:string,10,maxLength,,Recommended,
 297,CourseAchievementShape,pesc:courseAcademicGradeStatusCode,Course Academic Grade Status Code,FALSE,FALSE,IRI,,"pescGradeStatusCodes:AuditedCourse
@@ -168,7 +167,6 @@ pescRepeatCodes:NotCountedOther",picklist,,Recommended,
 316,CourseAchievementShape,pesc:courseAddDate,Course Add Date,FALSE,FALSE,Literal,xsd:date,,,,Optional,
 321,CourseAchievementShape,pesc:courseBeginDate,Course Begin Date,FALSE,FALSE,Literal,xsd:date,,,,Optional,
 322,CourseAchievementShape,pesc:courseEndDate,Course End Date,FALSE,FALSE,Literal,xsd:date,,,,Optional,
-349,CourseAchievementShape,pesc:licensure,Licensure,FALSE,TRUE,IRI BNODE,,,,LicensureShape,Optional,
 326,CourseSupplementalGradeShape,pesc:supplementalGradeCode,Supplemental Grade Code,FALSE,FALSE,IRI,,"pescSupplementalGradeCodes:BiCourseGrade
 pescSupplementalGradeCodes:BlendedFinalGrade
 pescSupplementalGradeCodes:ExamGrade
@@ -218,6 +216,8 @@ pescCreditUnits:Other",picklist,,,
 ,,,,,,,,,,,,
 350,LicensureShape,pesc:licensureName,Licensure Name,FALSE,TRUE,Literal,xsd:string,60,maxLength,,Recommended,
 351,LicensureShape,pesc:licensurePassageDate,Licensure Passage Date,FALSE,TRUE,Literal,xsd:date,,,,Optional,
+,LicensureShape,pesc:inProgram,In Program,FALSE,FALSE,IRI BNODE,,,,AcademicProgramShape,,
+,LicensureShape,pesc:inCourse,In Course,FALSE,FALSE,IRI BNODE,,,,CourseShape,,
 ,NoteShape,rdf:type,Type,FALSE,FALSE,IRI,,elm:Note,,,,
 ,NoteShape,elm:noteLiteral,Note literal,TRUE,TRUE,Literal,,,,,,
 ,ProgramSummaryShape,pesc:inProgram,In Program,TRUE,TRUE,IRI BNODE,,,,AcademicProgramShape,Recommended,


### PR DESCRIPTION
remove licensure property from AcademicAward; add inCourse and inPrograme to LicensureShape

No changes tests, they can wait until do mapping to CEDS.

closes #48 